### PR TITLE
Restoring sessions

### DIFF
--- a/OpenTidl/Methods/OpenTidlSession.cs
+++ b/OpenTidl/Methods/OpenTidlSession.cs
@@ -28,7 +28,7 @@ using OpenTidl.Transport;
 
 namespace OpenTidl.Methods
 {
-    public class OpenTidlSession : IDisposable
+    public class OpenTidlSession
     {
         #region properties
 
@@ -465,22 +465,12 @@ namespace OpenTidl.Methods
             return this.OpenTidlClient.HandleResponse(response);
         }
 
-        public void Dispose()
-        {
-            try
-            {
-                if (this.LoginResult != null)
-                    this.Logout().Sync(1000);
-            }
-            catch { }
-        }
-
         #endregion
 
 
         #region construction
 
-        internal OpenTidlSession(OpenTidlClient client, LoginModel loginModel)
+        public OpenTidlSession(OpenTidlClient client, LoginModel loginModel)
         {
             this.OpenTidlClient = client;
             this.LoginResult = loginModel;


### PR DESCRIPTION
Since the Tidal API supports persistent sessions, it is a good idea to be able to just store the user's session token on a successful login, then use it to reinitialise the API when the application is restarted. It also seems wasteful to implement IDisposable, as when it is disposed of everything will block as the request is completed.
