### PR TITLE
Updates models to reflect current json models

### DIFF
--- a/OpenTidl/Models/AlbumModel.cs
+++ b/OpenTidl/Models/AlbumModel.cs
@@ -87,6 +87,12 @@ namespace OpenTidl.Models
         [DataMember(Name = "premiumStreamingOnly")]
         public Boolean PremiumStreamingOnly { get; private set; }
 
+        [DataMember(Name = "upc")]
+        public String Upc { get; private set; }
+
+        [DataMember(Name = "audioQuality")]
+        public String AudioQuality { get; private set; }
+
 
         #region json helpers
 

--- a/OpenTidl/Models/PlaylistModel.cs
+++ b/OpenTidl/Models/PlaylistModel.cs
@@ -42,10 +42,7 @@ namespace OpenTidl.Models
 
         [DataMember(Name = "duration")]
         public Int32 Duration { get; private set; }
-
-        [DataMember(Name = "id")]
-        public Int32 Id { get; private set; }
-
+        
         [DataMember(Name = "image")]
         public String Image { get; private set; }
 

--- a/OpenTidl/Models/TrackModel.cs
+++ b/OpenTidl/Models/TrackModel.cs
@@ -79,6 +79,11 @@ namespace OpenTidl.Models
         [DataMember(Name = "copyright")]
         public String Copyright { get; private set; }
 
+        [DataMember(Name = "isrc")]
+        public String Isrc { get; private set; }
+
+        [DataMember(Name = "audioQuality")]
+        public String AudioQuality { get; private set; }
 
         #region json helpers
 


### PR DESCRIPTION
The following models are updated:
* AlbumModel: Added UPC and AudioQuality
* TrackModel: Added ISRC and AudioQuality
* PlaylistModel: Removed ID

These changes are in accordance with the current JSON results from api.tidalhifi.com, e.g.:
* https://api.tidalhifi.com/v1/albums/90641744
* https://api.tidalhifi.com/v1/tracks/90641745
* https://api.tidalhifi.com/v1/playlists/26ce488d-7ede-49f7-ae4e-1b9e9c3dadd5

UUID is the identifier for a playlist, ID is no longer present.